### PR TITLE
update publish script to just publish contents of dist dir

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -24,6 +24,16 @@ case "$TARGET" in
         ;;
 esac
 
+if [ ! -d "./dist" ] || [ ! "$(ls -A ./dist)" ];
+then
+    echo ""
+    echo "-----------------------------------------------------------------------------------"
+    echo "ERROR: dist directory does not exist or is empty."
+    echo "Please compile site content before publishing"
+    echo ""
+    exit 1
+fi
+
 echo "==================================================================="
 echo "About to publish site content to: $TARGET"
 echo "$TARGET_URL"
@@ -32,20 +42,26 @@ read -p "Proceed? (y/n) : " REPLY;
 
 if [[ $REPLY =~ ^[Yy]$ ]]; then
 
-    echo "---------------------------------------"
-    echo "Step 1: Compile Site"
-    echo "---------------------------------------"
-    gulp dist
+    # echo "---------------------------------------"
+    # echo "Step 1: Compile Site"
+    # echo "---------------------------------------"
+    # gulp dist
 
     echo ""
     echo "---------------------------------------"
-    echo "Step 2: Sync to S3"
+    echo "Step 1: Sync to S3"
+    echo "---------------------------------------"
+
+
+    echo ""
+    echo "---------------------------------------"
+    echo "Step 1: Sync to S3"
     echo "---------------------------------------"
     aws s3 sync dist/ $TARGET_URL
 
     echo ""
     echo "---------------------------------------"
-    echo "Step 3: Create CloudFront invalidation"
+    echo "Step 2: Create CloudFront invalidation"
     echo "---------------------------------------"
     aws cloudfront create-invalidation \
         --distribution-id $CLOUD_FRONT_DISTRIBUTION_ID \


### PR DESCRIPTION
updated the publish script to NOT do a gulp dist before publishing content. It will now check that a non-empty dist folder exists before publishing.

content will need to be generated separately before publishing. 